### PR TITLE
Updates CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.0.2]
+
+### Added
+
+- Entrypoint for CLI to localize data via internet
+
+### Changed
+
+- CLI entrypoints now utilize `dist-s1 run_sas` and `dist-s1 run` rathern than just `dist-s1`. 
+  - The `dist-s1 run_sas` is the primary entrypoint for Science Application Software (SAS) for SDS operations. 
+  - The `dist-s1 run` is the simplified entrypoint for external users, allowing for the localization of data from publicly available data sources.
+
 ## [0.0.1]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Homepage = "https://github.com/opera-adt/dist-s1"
 "Changelog" = "https://github.com/opera-adt/dist-s1/releases"
 
 [project.scripts]
-"dist_s1" = "dist_s1.__main__:main"
+"dist_s1" = "dist_s1.__main__:cli"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -24,19 +24,28 @@ def cli():
 @click.option('--runconfig_yml_path', required=True, help='Path to YAML runconfig file', type=click.Path(exists=True))
 def run_sas(runconfig_yml_path: str | Path):
     runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
-    run_dist_s1_workflow(runconfig_data)
+    out_dir = run_dist_s1_workflow(runconfig_data)
+    click.echo(f'Writing to DIST-S1 product to directory: {out_dir}')
+    return str(out_dir)
 
 
 # MGRS Workflow with Internet Access
 @cli.command(name='run')
 @click.option('--mgrs_tile_id', type=str, required=True, help='MGRS tile ID.')
 @click.option('--post_date', type=str, required=True, help='Post acquisition date.')
-@click.option('--track_number', type=int, required=True, help='Sentinel-1 Track number.')
-@click.option('--post_buffer_days', type=int, required=True, help='Buffer days around post-date.')
-def run(mgrs_tile_id: str, post_date: str, track_number: int, post_buffer_days: int):
+@click.option(
+    '--track_number',
+    type=int,
+    required=False,
+    default=1,
+    help='Sentinel-1 Track Number; Supply one from the group of bursts collected from a pass; '
+    'Near the dateline you may have two sequential track numbers.',
+)
+@click.option('--post_date_buffer_days', type=int, required=True, help='Buffer days around post-date.')
+def run(mgrs_tile_id: str, post_date: str, track_number: int, post_date_buffer_days: int):
     """Localize data and run dist_s1_workflow."""
     # Localize data
-    _ = localize_data(mgrs_tile_id, post_date, track_number, post_buffer_days)
+    _ = localize_data(mgrs_tile_id, post_date, track_number, post_date_buffer_days)
     # TODO: Run the workflow with localized data
     return 'output_path'
 

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import click
@@ -6,12 +7,39 @@ from .dist_s1_workflow import run_dist_s1_workflow
 from .input_data_model import RunConfigModel
 
 
+def localize_data(mgrs_tile_id: str, post_date: str | datetime, track: int, post_buffer_days: int):
+    """Dummy function to localize data."""
+    click.echo('Localizing data')
+    return {'mgrs_tile_id': mgrs_tile_id, 'post_date': post_date, 'track': track, 'buffer_days': post_buffer_days}
+
+
+@click.group()
+def cli():
+    """CLI for dist-s1 workflows."""
+    pass
+
+
+# SAS Workflow (No Internet Access)
+@cli.command(name='run_sas')
 @click.option('--runconfig_yml_path', required=True, help='Path to YAML runconfig file', type=click.Path(exists=True))
-@click.command()
-def main(runconfig_yml_path: str | Path):
+def run_sas(runconfig_yml_path: str | Path):
     runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
     run_dist_s1_workflow(runconfig_data)
 
 
+# MGRS Workflow with Internet Access
+@cli.command(name='run')
+@click.option('--mgrs_tile_id', type=str, required=True, help='MGRS tile ID.')
+@click.option('--post_date', type=str, required=True, help='Post acquisition date.')
+@click.option('--track_number', type=int, required=True, help='Sentinel-1 Track number.')
+@click.option('--post_buffer_days', type=int, required=True, help='Buffer days around post-date.')
+def run(mgrs_tile_id: str, post_date: str, track_number: int, post_buffer_days: int):
+    """Localize data and run dist_s1_workflow."""
+    # Localize data
+    _ = localize_data(mgrs_tile_id, post_date, track_number, post_buffer_days)
+    # TODO: Run the workflow with localized data
+    return 'output_path'
+
+
 if __name__ == '__main__':
-    main()
+    cli()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from dist_s1.__main__ import main as dist_s1
+from dist_s1.__main__ import cli as dist_s1
 from dist_s1.input_data_model import RunConfigModel
 
 
@@ -10,7 +10,7 @@ def test_dist_s1_main(cli_runner, change_local_dir, test_dir, test_data_dir):
     runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
     result = cli_runner.invoke(
         dist_s1,
-        ['--runconfig_yml_path', runconfig_yml_path],
+        ['run_sas', '--runconfig_yml_path', runconfig_yml_path],
     )
     assert result.exit_code == 0
     assert runconfig_data.output_product_dir.exists()


### PR DESCRIPTION
Makes sure that we have two entrypoints `run` (for external users) and `run_sas` for SDS. Basically, `run` will functionally be two sequential steps, localizing all the inputs necessary for `run_sas` triggered by fewer inputs.