### PR TITLE
v0.0.2

### DIFF
--- a/.github/workflows/pypi-delivery.yml
+++ b/.github/workflows/pypi-delivery.yml
@@ -1,0 +1,37 @@
+name: Distribute to PyPI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    outputs:
+      SDIST_VERSION: ${{ steps.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools build "setuptools-scm[toml]"
+
+      - name: Build distribuion
+        id: build
+        run: |
+          git fetch origin +refs/tags/*:refs/tags/*
+          export SDIST_VERSION=$(python -m setuptools_scm)
+          echo "::set-output name=version::${SDIST_VERSION}"
+          python -m build
+
+      - name: upload to PyPI.org
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.OPERA_PST_PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [0.0.2]
 
 ### Added
 
+- Pypi delivery workflow
 - Entrypoint for CLI to localize data via internet
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.0.2]
+
+### Added
+
+- Entrypoint for CLI to localize data via internet
+
+### Changed
+
+- CLI entrypoints now utilize `dist-s1 run_sas` and `dist-s1 run` rathern than just `dist-s1`. 
+  - The `dist-s1 run_sas` is the primary entrypoint for Science Application Software (SAS) for SDS operations. 
+  - The `dist-s1 run` is the simplified entrypoint for external users, allowing for the localization of data from publicly available data sources.
+
 ## [0.0.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Pypi delivery workflow
-- Entrypoint for CLI to localize data via internet
+- Entrypoint for CLI to localize data via internet (the SAS workflow is assumed not to have internet access)
+- Data models for output data and product naming conventions
+- Ensures output products follow the product and the tif layers follow the expected naming conventions
+  - Provides testing/validation of the structure (via tmp directories)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/dist_s1)](https://anaconda.org/conda-forge/dist_s1)
 [![Conda platforms](https://img.shields.io/conda/pn/conda-forge/dist_s1)](https://anaconda.org/conda-forge/dist_s1)
 
-This is the workflow that generates OPERA's DIST-S1 product. This delineates *generic* disturbance from a time-series of OPERA Radiometric and Terrain Corrected Sentinel-1 (RTC-S1) products.
+This is the workflow that generates OPERA's DIST-S1 product. This workflow is designed to delineate *generic* disturbance from a time-series of OPERA Radiometric and Terrain Corrected Sentinel-1 (RTC-S1) products.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/dist_s1)](https://anaconda.org/conda-forge/dist_s1)
 [![Conda platforms](https://img.shields.io/conda/pn/conda-forge/dist_s1)](https://anaconda.org/conda-forge/dist_s1)
 
-This is the workflow that generates OPERA's DIST-S1 product.
+This is the workflow that generates OPERA's DIST-S1 product. This delineates *generic* disturbance from a time-series of OPERA Radiometric and Terrain Corrected Sentinel-1 (RTC-S1) products.
 
 ## Install
 
@@ -28,15 +28,25 @@ See `tests/test_main.py` for an example of how to use the CLI with sample data.
 
 ## Docker
 
-### Local Usage
+### Downloading a Docker Image
+
+```
+docker pull ghcr.io/asf-hyp3/dist-s1:<tag>
+```
+Where `<tag>` is the semantic version of the release you want to download.
+
+### Building the Docker Image Locally
 
 Make sure you have Docker installed (e.g. for MacOS: https://docs.docker.com/desktop/setup/install/mac-install/)
 
 ```
 docker build -f Dockerfile -t dist_s1_img .
 ```
+
+### Running the Container Interactively
+
 To run the container interactively:
 ```
 docker run -ti dist_s1_img
 ```
-Should be able to run the CLI commands and the test suite.
+Within the container, you can run the CLI commands and the test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Homepage = "https://github.com/opera-adt/dist-s1"
 "Changelog" = "https://github.com/opera-adt/dist-s1/releases"
 
 [project.scripts]
-"dist_s1" = "dist_s1.__main__:main"
+"dist_s1" = "dist_s1.__main__:cli"
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Homepage = "https://github.com/opera-adt/dist-s1"
 "Changelog" = "https://github.com/opera-adt/dist-s1/releases"
 
 [project.scripts]
-"dist_s1" = "dist_s1.__main__:cli"
+"dist-s1" = "dist_s1.__main__:cli"
 
 [tool.setuptools]
 include-package-data = true
@@ -44,6 +44,8 @@ exclude = ["notebooks*", "tests*"]
 [tool.setuptools.dynamic]
 readme = { file = ['README.md'], content-type = 'text/markdown' }
 
+[tool.setuptools.package-data]
+dist_s1 = ["py.typed"]
 
 [tool.setuptools_scm]
 

--- a/src/dist_s1/__init__.py
+++ b/src/dist_s1/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 from importlib.metadata import PackageNotFoundError, version
 
-from .input_data_model import RunConfigModel
+from .data_models.runconfig_model import RunConfigData
 
 
 try:
@@ -16,4 +16,4 @@ except PackageNotFoundError:
     )
 
 
-__all__ = ['RunConfigModel']
+__all__ = ['RunConfigData']

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import click
 
+from .data_models.runconfig_model import RunConfigData
 from .dist_s1_workflow import run_dist_s1_workflow
-from .input_data_model import RunConfigModel
 
 
 def localize_data(mgrs_tile_id: str, post_date: str | datetime, track: int, post_buffer_days: int):
@@ -23,10 +23,10 @@ def cli():
 @cli.command(name='run_sas')
 @click.option('--runconfig_yml_path', required=True, help='Path to YAML runconfig file', type=click.Path(exists=True))
 def run_sas(runconfig_yml_path: str | Path):
-    runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
-    out_dir = run_dist_s1_workflow(runconfig_data)
-    click.echo(f'Writing to DIST-S1 product to directory: {out_dir}')
-    return str(out_dir)
+    runconfig_data = RunConfigData.from_yaml(runconfig_yml_path)
+    out_dir_data = run_dist_s1_workflow(runconfig_data)
+    click.echo(f'Writing to DIST-S1 product to directory: {out_dir_data.path}')
+    return str(out_dir_data)
 
 
 # MGRS Workflow with Internet Access

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import click
@@ -6,12 +7,48 @@ from .dist_s1_workflow import run_dist_s1_workflow
 from .input_data_model import RunConfigModel
 
 
+def localize_data(mgrs_tile_id: str, post_date: str | datetime, track: int, post_buffer_days: int):
+    """Dummy function to localize data."""
+    click.echo('Localizing data')
+    return {'mgrs_tile_id': mgrs_tile_id, 'post_date': post_date, 'track': track, 'buffer_days': post_buffer_days}
+
+
+@click.group()
+def cli():
+    """CLI for dist-s1 workflows."""
+    pass
+
+
+# SAS Workflow (No Internet Access)
+@cli.command(name='run_sas')
 @click.option('--runconfig_yml_path', required=True, help='Path to YAML runconfig file', type=click.Path(exists=True))
-@click.command()
-def main(runconfig_yml_path: str | Path):
+def run_sas(runconfig_yml_path: str | Path):
     runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
-    run_dist_s1_workflow(runconfig_data)
+    out_dir = run_dist_s1_workflow(runconfig_data)
+    click.echo(f'Writing to DIST-S1 product to directory: {out_dir}')
+    return str(out_dir)
+
+
+# MGRS Workflow with Internet Access
+@cli.command(name='run')
+@click.option('--mgrs_tile_id', type=str, required=True, help='MGRS tile ID.')
+@click.option('--post_date', type=str, required=True, help='Post acquisition date.')
+@click.option(
+    '--track_number',
+    type=int,
+    required=False,
+    default=1,
+    help='Sentinel-1 Track Number; Supply one from the group of bursts collected from a pass; '
+    'Near the dateline you may have two sequential track numbers.',
+)
+@click.option('--post_date_buffer_days', type=int, required=True, help='Buffer days around post-date.')
+def run(mgrs_tile_id: str, post_date: str, track_number: int, post_date_buffer_days: int):
+    """Localize data and run dist_s1_workflow."""
+    # Localize data
+    _ = localize_data(mgrs_tile_id, post_date, track_number, post_date_buffer_days)
+    # TODO: Run the workflow with localized data
+    return 'output_path'
 
 
 if __name__ == '__main__':
-    main()
+    cli()

--- a/src/dist_s1/data_models/output_models.py
+++ b/src/dist_s1/data_models/output_models.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+from pathlib import Path
+from warnings import warn
+
+import rasterio
+from pydantic import BaseModel, field_validator
+
+
+PRODUCT_VERSION = '0.0.1'
+LAYERS = ['DIST-STATUS', 'DIST-STATUS-ACQ', 'GEN-METRIC', 'DATE-FIRST', 'DATE-LATEST', 'N-OBS', 'N-DIST']
+LAYER_DTYPES = {
+    'DIST-STATUS': 'uint8',
+    'DIST-STATUS-ACQ': 'uint8',
+    'GEN-METRIC': 'float32',
+    'DATE-FIRST': 'uint32',
+    'DATE-LATEST': 'uint32',
+    'N-OBS': 'uint32',
+    'N-DIST': 'uint32',
+}
+EXPECTED_FORMAT_STRING = (
+    'OPERA_L3_DIST-ALERT-S1_T{mgrs_tile_id}_{acq_datetime}_{proc_datetime}_S1_30_v{PRODUCT_VERSION}'
+)
+
+
+class ProductNameData(BaseModel):
+    mgrs_tile_id: str
+    acq_date_time: datetime
+    processing_date_time: datetime
+
+    def __str__(self):
+        tokens = [
+            'OPERA',
+            'L3',
+            'DIST-ALERT-S1',
+            f'T{self.mgrs_tile_id}',
+            self.acq_date_time.strftime('%Y%m%dT%H%M%SZ'),
+            self.processing_date_time.strftime('%Y%m%dT%H%M%SZ'),
+            'S1',
+            '30',
+            f'v{PRODUCT_VERSION}',
+        ]
+        return '_'.join(tokens)
+
+    def name(self):
+        return f'{self}'
+
+    @classmethod
+    def validate_product_name(cls, product_name: str) -> bool:
+        """
+        Validates if a string matches the OPERA L3 DIST-ALERT-S1 product name format.
+
+        Expected format:
+        OPERA_L3_DIST-ALERT-S1_T{mgrs_tile_id}_{acq_datetime}_{proc_datetime}_S1_30_v{version}
+        """
+        try:
+            tokens = product_name.split('_')
+
+            # Check if we have the correct number of tokens first
+            if len(tokens) != 9:
+                return False
+
+            conditions = [
+                tokens[0] != 'OPERA',
+                tokens[1] != 'L3',
+                tokens[2] != 'DIST-ALERT-S1',
+                not tokens[3].startswith('T'),  # MGRS tile ID
+                tokens[6] != 'S1',
+                tokens[7] != '30',
+                not tokens[8].startswith('v'),  # Version
+            ]
+
+            # If any condition is True, validation fails
+            if any(conditions):
+                return False
+
+            # Validate datetime formats
+            datetime.strptime(tokens[4], '%Y%m%dT%H%M%SZ')  # Acquisition datetime
+            datetime.strptime(tokens[5], '%Y%m%dT%H%M%SZ')  # Processing datetime
+
+            return True
+
+        except (ValueError, IndexError):
+            return False
+
+
+class ProductDirectoryData(BaseModel):
+    product_name: str
+    dst_dir: Path | str
+    layers: list[str] = LAYERS
+
+    @property
+    def path(self) -> Path:
+        path = self.dst_dir / self.product_name
+        return path
+
+    @field_validator('product_name')
+    @classmethod
+    def validate_product_name(cls, product_name: str) -> str:
+        if not ProductNameData.validate_product_name(product_name):
+            raise ValueError(f'Invalid product name: {product_name}; should match: {EXPECTED_FORMAT_STRING}')
+        return product_name
+
+    @field_validator('dst_dir')
+    @classmethod
+    def validate_product_directory(cls, dst_dir: Path | str, values: dict) -> Path:
+        if isinstance(dst_dir, str):
+            dst_dir = Path(dst_dir)
+        product_dir = dst_dir / values.data['product_name']
+        if product_dir.exists() and not product_dir.is_dir():
+            raise ValueError(f'Path {product_dir} exists but is not a directory')
+        if not product_dir.exists():
+            product_dir.mkdir(parents=True, exist_ok=True)
+        return dst_dir
+
+    @property
+    def layer_path_dict(self) -> dict[str, Path]:
+        return {layer: self.path / f'{self.product_name}_{layer}.tif' for layer in self.layers}
+
+    def validate_layer_paths(self) -> bool:
+        failed_layers = []
+        for layer, path in self.layer_path_dict.items():
+            if not path.exists():
+                warn(f'Layer {layer} does not exist at path: {path}', UserWarning)
+                failed_layers.append(layer)
+        return len(failed_layers) == 0
+
+    def validate_layer_dtypes(self) -> bool:
+        failed_layers = []
+        for layer, path in self.layer_path_dict.items():
+            with rasterio.open(path) as src:
+                if src.dtypes[0] != LAYER_DTYPES[layer]:
+                    warn(
+                        f'Layer {layer} has incorrect dtype: {src.dtypes[0]}; should be: {LAYER_DTYPES[layer]}',
+                        UserWarning,
+                    )
+                    failed_layers.append(layer)
+        return len(failed_layers) == 0

--- a/tests/test_data/10SGD_cropped/runconfig.yml
+++ b/tests/test_data/10SGD_cropped/runconfig.yml
@@ -335,5 +335,5 @@ run_config:
     - test_data/10SGD_cropped/137/2024-11-03/OPERA_L2_RTC-S1_T137-292325-IW1_20241103T015921Z_20241103T074936Z_S1A_30_v1.0_VH.tif
     mgrs_tile_id: 10SGD
     confirmation_db_dir:
-    output_product_dir:
+    dst_dir:
     water_mask:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,18 +1,30 @@
 from dist_s1.__main__ import cli as dist_s1
-from dist_s1.input_data_model import RunConfigModel
+from dist_s1.data_models.runconfig_model import RunConfigData
 
 
-def test_dist_s1_main(cli_runner, change_local_dir, test_dir, test_data_dir):
+def test_dist_s1_main(cli_runner, change_local_dir, test_dir, test_data_dir, tmpdir_factory):
     change_local_dir(test_dir)
 
-    # Run the command
-    runconfig_yml_path = str(test_data_dir / '10SGD_cropped' / 'runconfig.yml')
-    runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
+    # Read the template runconfig file and overwrite the dst_dir and the dist_s1_alert_db_dir fields to a tmpdir
+    tmp_dst_dir = tmpdir_factory.mktemp('tmpdir_dst_dir')
+    tmp_db_dir = tmpdir_factory.mktemp('tmpdir_db_dir')
+    template_runconfig_yml_path = str(test_data_dir / '10SGD_cropped' / 'runconfig.yml')
+    runconfig_data = RunConfigData.from_yaml(
+        template_runconfig_yml_path,
+        fields_to_overwrite={'dst_dir': str(tmp_dst_dir), 'dist_s1_alert_db_dir': str(tmp_db_dir)},
+    )
+
+    # Write the updated runconfig file to a product directory
+    tmp_runconfig_yml_path = tmp_dst_dir / 'runconfig.yml'
+    runconfig_data.to_yaml(tmp_runconfig_yml_path)
+
+    # Run the command using the updated runconfig file (the tmp files are cleaned up after the test)
     result = cli_runner.invoke(
         dist_s1,
-        ['run_sas', '--runconfig_yml_path', runconfig_yml_path],
+        ['run_sas', '--runconfig_yml_path', tmp_runconfig_yml_path],
     )
     assert result.exit_code == 0
-    assert runconfig_data.output_product_dir.exists()
-    assert runconfig_data.output_product_dir.is_dir()
-    # assert 'some_path' in result.output
+    assert runconfig_data.product_dir_data.path.exists()
+    assert runconfig_data.product_dir_data.path.is_dir()
+    assert runconfig_data.product_dir_data.validate_layer_paths()
+    assert runconfig_data.product_dir_data.validate_layer_dtypes()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from dist_s1.__main__ import main as dist_s1
+from dist_s1.__main__ import cli as dist_s1
 from dist_s1.input_data_model import RunConfigModel
 
 
@@ -10,7 +10,7 @@ def test_dist_s1_main(cli_runner, change_local_dir, test_dir, test_data_dir):
     runconfig_data = RunConfigModel.from_yaml(runconfig_yml_path)
     result = cli_runner.invoke(
         dist_s1,
-        ['--runconfig_yml_path', runconfig_yml_path],
+        ['run_sas', '--runconfig_yml_path', runconfig_yml_path],
     )
     assert result.exit_code == 0
     assert runconfig_data.output_product_dir.exists()

--- a/tests/test_runconfig_model.py
+++ b/tests/test_runconfig_model.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import geopandas as gpd
 
-from dist_s1.input_data_model import RunConfigModel
+from dist_s1.data_models.runconfig_model import RunConfigData
 
 
 def test_input_data_model_from_cropped_dataset(test_dir: Path, test_data_dir: Path, change_local_dir: Callable):
@@ -19,7 +19,7 @@ def test_input_data_model_from_cropped_dataset(test_dir: Path, test_data_dir: Pa
 
     mgrs_tile_id = '10SGD'
 
-    config = RunConfigModel(
+    config = RunConfigData(
         pre_rtc_copol=pre_rtc_copol_paths,
         pre_rtc_crosspol=pre_rtc_crosspol_paths,
         post_rtc_copol=post_rtc_copol_paths,


### PR DESCRIPTION
### Added

- Pypi delivery workflow
- Entrypoint for CLI to localize data via internet (the SAS workflow is assumed not to have internet access)
- Data models for output data and product naming conventions
- Ensures output products follow the product and the tif layers follow the expected naming conventions
  - Provides testing/validation of the structure (via tmp directories)

### Changed

- CLI entrypoints now utilize `dist-s1 run_sas` and `dist-s1 run` rathern than just `dist-s1`. 
  - The `dist-s1 run_sas` is the primary entrypoint for Science Application Software (SAS) for SDS operations. 
  - The `dist-s1 run` is the simplified entrypoint for external users, allowing for the localization of data from publicly available data sources.