### PR TITLE
Fix CLI Test and Path issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Issues with test_main.py related to where tmp directory was being created (solution, ensure tmp is made explicitly relative to the test directory as in `test_workflows.py`).
 - All dependencies within virtual environment are back to conda-forge from PyPI.
 - Product directory parameter is now correctly writing to the specified directory (fixes [#37](https://github.com/opera-adt/dist-s1/issues/37)).
-- Update CLI test with isolated filesystem to ensure the working directory is correct.
-- Fixed the CLI test bug the runconfig instance will have different product paths than the one created via the CLI.
+- Fixed the CLI test (bug). The runconfig instance will have different product paths than the one created via the CLI because the product paths have the *processing time* in them, and that is different depending on when the runconfig object is created in the test and within the CLI-run test.
 
 ### Added
 - Added a `n_workers_for_despeckling` argument to the `RunConfigData` model, CLI, and relevant processing functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - All dependencies within virtual environment are back to conda-forge from PyPI.
 - Product directory parameter is now correctly writing to the specified directory (fixes [#37](https://github.com/opera-adt/dist-s1/issues/37)).
 - Update CLI test with isolated filesystem to ensure the working directory is correct.
-
+- Fixed the CLI test bug the runconfig instance will have different product paths than the one created via the CLI.
 
 ### Added
 - Added a `n_workers_for_despeckling` argument to the `RunConfigData` model, CLI, and relevant processing functions.

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -149,7 +149,7 @@ def run_sas_prep(
     bucket: str | None,
     bucket_prefix: str,
     n_workers_for_despeckling: int,
-) -> str:
+) -> None:
     """Run SAS prep workflow."""
     run_config = run_dist_s1_sas_prep_workflow(
         mgrs_tile_id,
@@ -176,9 +176,9 @@ def run_sas_prep(
 # SAS Workflow (No Internet Access)
 @cli.command(name='run_sas')
 @click.option('--runconfig_yml_path', required=True, help='Path to YAML runconfig file', type=click.Path(exists=True))
-def run_sas(runconfig_yml_path: str | Path) -> str:
-    runconfig_data = RunConfigData.from_yaml(runconfig_yml_path)
-    run_dist_s1_sas_workflow(runconfig_data)
+def run_sas(runconfig_yml_path: str | Path) -> None:
+    run_config = RunConfigData.from_yaml(runconfig_yml_path)
+    run_dist_s1_sas_workflow(run_config)
 
 
 # Effectively runs the two workflows above in sequence

--- a/src/dist_s1/workflows.py
+++ b/src/dist_s1/workflows.py
@@ -312,6 +312,7 @@ def run_dist_s1_sas_prep_workflow(
     product_dst_dir: str | Path | None = None,
     bucket: str | None = None,
     bucket_prefix: str = '',
+    n_workers_for_despeckling: int = 5,
 ) -> RunConfigData:
     run_config = run_dist_s1_localization_workflow(
         mgrs_tile_id,
@@ -331,6 +332,7 @@ def run_dist_s1_sas_prep_workflow(
     run_config.product_dst_dir = product_dst_dir
     run_config.bucket = bucket
     run_config.bucket_prefix = bucket_prefix
+    run_config.n_workers_for_despeckling = n_workers_for_despeckling
     return run_config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def test_opera_golden_dummy_dataset() -> Path:
     golden_datasets_dir = test_dir.parent / 'test_data' / 'golden_datasets' / '10SGD'
     golden_dummy_dataset = (
         golden_datasets_dir / 'OPERA_L3_DIST-ALERT-S1_T10SGD_20250102T015857Z_20250211T180230Z_S1_30_v0.1'
-    )
+    ).resolve()
     return golden_dummy_dataset
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
-import os
-import shutil
+from collections.abc import Callable
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -12,6 +11,7 @@ from dist_s1.data_models.runconfig_model import RunConfigData
 def test_dist_s1_sas_main(
     cli_runner: CliRunner,
     test_dir: Path,
+    change_local_dir: Callable[[Path], None],
     cropped_10SGD_dataset_runconfig: Path,
     test_opera_golden_dummy_dataset: Path,
 ) -> None:
@@ -24,59 +24,41 @@ def test_dist_s1_sas_main(
     And comparing the output product directory to the golden dummy dataset.
 
     Note: the hardest part is serializing the runconfig to yml and then correctly finding the generated product.
-    This is because the product paths from the in-memory runconfig object are different from the ones created via the yml.
+    This is because the product paths from the in-memory runconfig object are different from the ones created via yml.
     This is because the product paths have the *processing time* in them, and that is different depending on when the
     runconfig object is created.
     """
     # Store original working directory
-    original_cwd = Path.cwd()
+    change_local_dir(test_dir)
+    tmp_dir = test_dir / 'tmp'
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
     product_data_golden = ProductDirectoryData.from_product_path(test_opera_golden_dummy_dataset)
 
-    with cli_runner.isolated_filesystem() as isolated_dir:
-        # Create a new test directory structure inside the isolated filesystem
-        isolated_test_dir = Path(isolated_dir) / 'test_dir'
-        isolated_test_dir.mkdir(parents=True)
-        os.chdir(isolated_test_dir)
+    # Load and modify runconfig - not the paths are relative to the test_dir
+    runconfig_data = RunConfigData.from_yaml(cropped_10SGD_dataset_runconfig)
+    # We have a different product_dst_dir than the dst_dir called `tmp2`
+    product_dst_dir = test_dir / 'tmp2'
+    assert runconfig_data.product_dst_dir.resolve() == product_dst_dir.resolve()
 
-        # Copy necessary test data into the isolated filesystem
-        shutil.copytree(test_dir / 'test_data', isolated_test_dir / 'test_data')
+    tmp_runconfig_yml_path = tmp_dir / 'runconfig.yml'
+    runconfig_data.to_yaml(tmp_runconfig_yml_path)
 
-        # Create temporary directories in the isolated filesystem
-        tmp_dir = isolated_test_dir / 'tmp'
-        tmp_dir.mkdir(parents=True)
-        product_dst_dir = isolated_test_dir / 'tmp2'
+    # Run the command
+    result = cli_runner.invoke(
+        dist_s1,
+        ['run_sas', '--runconfig_yml_path', str(tmp_runconfig_yml_path)],
+    )
+    # The product_dst_dir is created - have to find it because it has a processing time
+    # and will be different from the runconfig data object
+    product_directories = list(product_dst_dir.glob('OPERA*'))
+    # Should be one and only one product directory
+    assert len(product_directories) == 1
+    product_data_path = product_directories[0]
+    out_product_data = ProductDirectoryData.from_product_path(product_data_path)
 
-        # Load and modify runconfig - not the paths are relative to the test_dir
-        runconfig_data = RunConfigData.from_yaml(cropped_10SGD_dataset_runconfig)
-        runconfig_data.dst_dir = tmp_dir
-        # We have a different product_dst_dir than the dst_dir
-        assert runconfig_data.product_dst_dir.resolve() == product_dst_dir.resolve()
-        # We are going to remove this (it will get recreated at runtime)
+    # Check the product_dst_dir exists
+    assert product_dst_dir.exists()
+    assert result.exit_code == 0
 
-        tmp_runconfig_yml_path = tmp_dir / 'runconfig.yml'
-        runconfig_data.to_yaml(tmp_runconfig_yml_path)
-
-        # Change to the isolated test directory
-        os.chdir(isolated_test_dir)
-
-        # Run the command
-        result = cli_runner.invoke(
-            dist_s1,
-            ['run_sas', '--runconfig_yml_path', str(tmp_runconfig_yml_path)],
-        )
-        # The product_dst_dir is created - have to find it because it has a processing time
-        # and will be different from the runconfig data object
-        product_directories = list(product_dst_dir.glob('OPERA*'))
-        # Should be one and only one product directory
-        assert len(product_directories) == 1
-        product_data_path = product_directories[0]
-        out_product_data = ProductDirectoryData.from_product_path(product_data_path)
-
-        # Check the product_dst_dir exists
-        assert product_dst_dir.exists()
-        assert result.exit_code == 0
-
-        assert out_product_data == product_data_golden
-
-    # Return to original directory
-    os.chdir(original_cwd)
+    assert out_product_data == product_data_golden

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,47 +22,61 @@ def test_dist_s1_sas_main(
     `dist-s1 run_sas --runconfig_yml_path test_data/cropped/sample_runconfig_10SGD_cropped.yml`
 
     And comparing the output product directory to the golden dummy dataset.
+
+    Note: the hardest part is serializing the runconfig to yml and then correctly finding the generated product.
+    This is because the product paths from the in-memory runconfig object are different from the ones created via the yml.
+    This is because the product paths have the *processing time* in them, and that is different depending on when the
+    runconfig object is created.
     """
-    cwd = Path.cwd()
-    os.chdir(test_dir)
+    # Store original working directory
+    original_cwd = Path.cwd()
+    product_data_golden = ProductDirectoryData.from_product_path(test_opera_golden_dummy_dataset)
 
-    # Even though we change our local directory, this path needs to be made relative to the relevant test dir to avoid
-    # Issues in CI/CD
-    tmp_dir = test_dir / Path('tmp')
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-    # Check the runconfig.yml and see it is tmp2 - want to make sure this is correctly being set
-    product_dst_dir = test_dir / Path('tmp2')
+    with cli_runner.isolated_filesystem() as isolated_dir:
+        # Create a new test directory structure inside the isolated filesystem
+        isolated_test_dir = Path(isolated_dir) / 'test_dir'
+        isolated_test_dir.mkdir(parents=True)
+        os.chdir(isolated_test_dir)
 
-    runconfig_data = RunConfigData.from_yaml(cropped_10SGD_dataset_runconfig)
-    runconfig_data.dst_dir = tmp_dir
-    assert runconfig_data.product_dst_dir.resolve() == product_dst_dir.resolve()
+        # Copy necessary test data into the isolated filesystem
+        shutil.copytree(test_dir / 'test_data', isolated_test_dir / 'test_data')
 
-    tmp_runconfig_yml_path = tmp_dir / 'runconfig.yml'
-    runconfig_data.to_yaml(tmp_runconfig_yml_path)
+        # Create temporary directories in the isolated filesystem
+        tmp_dir = isolated_test_dir / 'tmp'
+        tmp_dir.mkdir(parents=True)
+        product_dst_dir = isolated_test_dir / 'tmp2'
 
-    # Run the command using the updated runconfig file (the tmp files are cleaned up after the test)
-    dist_s1_command = ['run_sas', '--runconfig_yml_path', str(tmp_runconfig_yml_path)]
+        # Load and modify runconfig - not the paths are relative to the test_dir
+        runconfig_data = RunConfigData.from_yaml(cropped_10SGD_dataset_runconfig)
+        runconfig_data.dst_dir = tmp_dir
+        # We have a different product_dst_dir than the dst_dir
+        assert runconfig_data.product_dst_dir.resolve() == product_dst_dir.resolve()
+        # We are going to remove this (it will get recreated at runtime)
 
-    with cli_runner.isolated_filesystem():
-        os.chdir(test_dir)
-        print(Path.cwd())
+        tmp_runconfig_yml_path = tmp_dir / 'runconfig.yml'
+        runconfig_data.to_yaml(tmp_runconfig_yml_path)
+
+        # Change to the isolated test directory
+        os.chdir(isolated_test_dir)
+
+        # Run the command
         result = cli_runner.invoke(
             dist_s1,
-            dist_s1_command,
+            ['run_sas', '--runconfig_yml_path', str(tmp_runconfig_yml_path)],
         )
+        # The product_dst_dir is created - have to find it because it has a processing time
+        # and will be different from the runconfig data object
+        product_directories = list(product_dst_dir.glob('OPERA*'))
+        # Should be one and only one product directory
+        assert len(product_directories) == 1
+        product_data_path = product_directories[0]
+        out_product_data = ProductDirectoryData.from_product_path(product_data_path)
 
         # Check the product_dst_dir exists
         assert product_dst_dir.exists()
-
         assert result.exit_code == 0
-
-        product_data_golden = ProductDirectoryData.from_product_path(test_opera_golden_dummy_dataset)
-        out_product_data = runconfig_data.product_data_model
 
         assert out_product_data == product_data_golden
 
-        shutil.rmtree(tmp_dir)
-        shutil.rmtree(product_dst_dir)
-
-    # return back to the original directory
-    os.chdir(cwd)
+    # Return to original directory
+    os.chdir(original_cwd)


### PR DESCRIPTION
The CLI using a runconfig yml file will create (slightly) different product paths than a runconfig object in memory because the paths have the processing time in them and there are few seconds between when the paths are generated.