### PR TITLE
Expose batch_size, stride and optimization params from transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2025-05-22
+
+### Added
+- Updated workflows.py, processing.py, and runconfig_model.py to accept
+stride_for_norm_param_estimation, batch_size_for_norm_param_estimation, 
+optimize params.
+
 ## [0.0.10] - 2025-05-19
 
 ### Added

--- a/src/dist_s1/__main__.py
+++ b/src/dist_s1/__main__.py
@@ -158,6 +158,29 @@ def common_options(func: Callable) -> Callable:
         required=False,
         help='Path to Transformer model weights file.',
     )
+    @click.option(
+        '--stride_for_norm_param_estimation',
+        type=int,
+        default=16,
+        required=False,
+        help='Batch size for norm param. Number of pixels the'
+        ' convolutional filter moves across the input image at'
+        ' each step.'
+    )
+    @click.option(
+        '--batch_size_for_norm_param_estimation',
+        type=int,
+        default=32,
+        required=False,
+        help='Batch size for norm param estimation; Tune it according to resouces i.e. memory.',
+    )
+    @click.option(
+        '--optimize',
+        type=bool,
+        default=True,
+        required=False,
+        help='Flag to enable compilation duringe execution.',
+    )
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         return func(*args, **kwargs)
@@ -200,6 +223,9 @@ def run_sas_prep(
     model_source: str | None,
     model_cfg_path: str | Path | None,
     model_wts_path: str | Path | None,
+    stride_for_norm_param_estimation: int = 16,
+    batch_size_for_norm_param_estimation: int = 32,
+    optimize: bool = True
 ) -> None:
     """Run SAS prep workflow."""
     run_config = run_dist_s1_sas_prep_workflow(
@@ -226,6 +252,9 @@ def run_sas_prep(
         model_source=model_source,
         model_cfg_path=model_cfg_path,
         model_wts_path=model_wts_path,
+        stride_for_norm_param_estimation=stride_for_norm_param_estimation,
+        batch_size_for_norm_param_estimation=batch_size_for_norm_param_estimation,
+        optimize=optimize
     )
     run_config.to_yaml(runconfig_path)
 
@@ -266,6 +295,9 @@ def run(
     model_source: str | None,
     model_cfg_path: str | Path | None,
     model_wts_path: str | Path | None,
+    stride_for_norm_param_estimation: int = 16,
+    batch_size_for_norm_param_estimation: int = 32,
+    optimize: bool = True
 ) -> str:
     """Localize data and run dist_s1_workflow."""
     return run_dist_s1_workflow(
@@ -292,6 +324,9 @@ def run(
         model_source=model_source,
         model_cfg_path=model_cfg_path,
         model_wts_path=model_wts_path,
+        stride_for_norm_param_estimation=stride_for_norm_param_estimation,
+        batch_size_for_norm_param_estimation=batch_size_for_norm_param_estimation,
+        optimize=optimize
     )
 
 

--- a/src/dist_s1/data_models/runconfig_model.py
+++ b/src/dist_s1/data_models/runconfig_model.py
@@ -142,7 +142,7 @@ class RunConfigData(BaseModel):
         ge=1,
     )
     stride_for_norm_param_estimation: int = Field(
-        default=2,
+        default=16,
         ge=1,
         le=16,
     )

--- a/src/dist_s1/data_models/runconfig_model.py
+++ b/src/dist_s1/data_models/runconfig_model.py
@@ -133,12 +133,21 @@ class RunConfigData(BaseModel):
         pattern='^(high|low)$',
     )
     tqdm_enabled: bool = Field(default=True)
-    batch_size_for_despeckling: int = Field(
-        default=25,
-        ge=1,
-    )
     n_workers_for_norm_param_estimation: int = Field(
         default=8,
+        ge=1,
+    )
+    batch_size_for_norm_param_estimation: int = Field(
+        default=32,
+        ge=1,
+    )
+    stride_for_norm_param_estimation: int = Field(
+        default=2,
+        ge=1,
+        le=16,
+    )
+    batch_size_for_despeckling: int = Field(
+        default=25,
         ge=1,
     )
     n_workers_for_despeckling: int = Field(
@@ -149,6 +158,9 @@ class RunConfigData(BaseModel):
     # This is where default thresholds are set!
     moderate_confidence_threshold: float = Field(default=3.5, ge=0.0, le=15.0)
     high_confidence_threshold: float = Field(default=5.5, ge=0.0, le=15.0)
+
+    optimize: bool = Field(default=False)
+
     product_dst_dir: Path | str | None = None
     bucket: str | None = None
     bucket_prefix: str = ''

--- a/src/dist_s1/data_models/runconfig_model.py
+++ b/src/dist_s1/data_models/runconfig_model.py
@@ -137,10 +137,12 @@ class RunConfigData(BaseModel):
         default=8,
         ge=1,
     )
+    # Batch size for transformer model.
     batch_size_for_norm_param_estimation: int = Field(
         default=32,
         ge=1,
     )
+    # Stride for transformer model.
     stride_for_norm_param_estimation: int = Field(
         default=16,
         ge=1,
@@ -159,7 +161,9 @@ class RunConfigData(BaseModel):
     moderate_confidence_threshold: float = Field(default=3.5, ge=0.0, le=15.0)
     high_confidence_threshold: float = Field(default=5.5, ge=0.0, le=15.0)
 
-    optimize: bool = Field(default=False)
+    # Flag to enable optimizations. False, load the model and use it.
+    # True, load the model and compile for CPU or GPU
+    optimize: bool = Field(default=True)
 
     product_dst_dir: Path | str | None = None
     bucket: str | None = None

--- a/src/dist_s1/processing.py
+++ b/src/dist_s1/processing.py
@@ -53,14 +53,17 @@ def compute_normal_params_per_burst_and_serialize(
     out_path_sigma_copol: Path,
     out_path_sigma_crosspol: Path,
     memory_strategy: str = 'high',
+    stride: int = 2,
+    batch_size: int = 32,
     device: str = 'best',
+    optimize: bool = False
 ) -> Path:
     if device not in ('cpu', 'cuda', 'mps', 'best'):
         raise ValueError(f'Invalid device: {device}')
     # For distmetrics, None is how we choose the "best" available device
     if device == 'best':
         device = None
-    model = load_transformer_model(device=device)
+    model = load_transformer_model(device=device, optimize=optimize, batch_size=batch_size)
 
     copol_data = [open_one_ds(path) for path in pre_copol_paths_dskpl_paths]
     crosspol_data = [open_one_ds(path) for path in pre_crosspol_paths_dskpl_paths]
@@ -75,7 +78,8 @@ def compute_normal_params_per_burst_and_serialize(
         check_profiles_match(p_ref, p_crosspol)
 
     logits_mu, logits_sigma = estimate_normal_params_of_logits(
-        model, arrs_copol, arrs_crosspol, memory_strategy=memory_strategy, device=device
+        model, arrs_copol, arrs_crosspol, memory_strategy=memory_strategy, device=device, stride=stride,
+        batch_size=batch_size,
     )
     logits_mu_copol, logits_mu_crosspol = logits_mu[0, ...], logits_mu[1, ...]
     logits_sigma_copol, logits_sigma_crosspol = logits_sigma[0, ...], logits_sigma[1, ...]

--- a/src/dist_s1/workflows.py
+++ b/src/dist_s1/workflows.py
@@ -414,6 +414,9 @@ def run_dist_s1_sas_prep_workflow(
     model_source: str | None = None,
     model_cfg_path: str | Path | None = None,
     model_wts_path: str | Path | None = None,
+    stride_for_norm_param_estimation: int = 16,
+    batch_size_for_norm_param_estimation: int = 32,
+    optimize: bool = True
 ) -> RunConfigData:
     run_config = run_dist_s1_localization_workflow(
         mgrs_tile_id,
@@ -442,6 +445,9 @@ def run_dist_s1_sas_prep_workflow(
     run_config.model_source = model_source
     run_config.model_cfg_path = model_cfg_path
     run_config.model_wts_path = model_wts_path
+    run_config.stride_for_norm_param_estimation = stride_for_norm_param_estimation
+    run_config.batch_size_for_norm_param_estimation = batch_size_for_norm_param_estimation
+    run_config.optimize = optimize
     return run_config
 
 
@@ -479,6 +485,9 @@ def run_dist_s1_workflow(
     model_source: str | None = None,
     model_cfg_path: str | Path | None = None,
     model_wts_path: str | Path | None = None,
+    stride_for_norm_param_estimation: int = 16,
+    batch_size_for_norm_param_estimation: int = 32,
+    optimize: bool = True
 ) -> Path:
     run_config = run_dist_s1_sas_prep_workflow(
         mgrs_tile_id,
@@ -504,6 +513,9 @@ def run_dist_s1_workflow(
         model_source=model_source,
         model_cfg_path=model_cfg_path,
         model_wts_path=model_wts_path,
+        stride_for_norm_param_estimation=stride_for_norm_param_estimation,
+        batch_size_for_norm_param_estimation=batch_size_for_norm_param_estimation,
+        optimize=optimize
     )
     _ = run_dist_s1_sas_workflow(run_config)
 
@@ -560,6 +572,9 @@ def run_dist_s1_sas_prep_runconfig_yml(run_config_template_yml_path: Path | str)
     batch_size_for_despeckling = rc_data.get('batch_size_for_despeckling', 25)
     n_workers_for_norm_param_estimation = rc_data.get('n_workers_for_norm_param_estimation', 1)
     device = rc_data.get('device', 'cpu')
+    stride_for_norm_param_estimation = rc_data.get('stride_for_norm_param_estimation', 16)
+    batch_size_for_norm_param_estimation = rc_data.get('batch_size_for_norm_param_estimation', 32)
+    optimize = rc_data.get('optimize', True)
 
     run_config = run_dist_s1_localization_workflow(
         mgrs_tile_id,
@@ -589,5 +604,8 @@ def run_dist_s1_sas_prep_runconfig_yml(run_config_template_yml_path: Path | str)
     run_config.model_cfg_path = model_cfg_path
     run_config.model_wts_path = model_wts_path
     run_config.device = device
+    run_config.stride_for_norm_param_estimation = stride_for_norm_param_estimation
+    run_config.batch_size_for_norm_param_estimation = batch_size_for_norm_param_estimation
+    run_config.optimize = optimize
 
     return run_config

--- a/src/dist_s1/workflows.py
+++ b/src/dist_s1/workflows.py
@@ -179,8 +179,15 @@ def run_despeckle_workflow(run_config: RunConfigData) -> None:
     )
 
 
-def _process_normal_params(path_data: dict, memory_strategy: str, device: str) -> None:
-    return compute_normal_params_per_burst_and_serialize(
+def _process_normal_params(
+        path_data: dict, 
+        memory_strategy: str, 
+        device: str, 
+        batch_size: int, 
+        stride: int, 
+        optimize: bool
+    ) -> None:
+    return x(
         path_data['copol_paths_pre'],
         path_data['crosspol_paths_pre'],
         path_data['output_mu_copol_path'],
@@ -189,6 +196,9 @@ def _process_normal_params(path_data: dict, memory_strategy: str, device: str) -
         path_data['output_sigma_crosspol_path'],
         memory_strategy=memory_strategy,
         device=device,
+        batch_size=batch_size,
+        stride=stride,
+        optimize=optimize
     )
 
 
@@ -230,6 +240,9 @@ def run_normal_param_estimation_workflow(run_config: RunConfigData) -> None:
                 path_data['output_sigma_crosspol_path'],
                 memory_strategy=run_config.memory_strategy,
                 device=run_config.device,
+                stride=run_config.stride_for_norm_param_estimation,
+                batch_size=run_config.batch_size_for_norm_param_estimation,
+                optimize=run_config.optimize
             )
     else:
         if run_config.device in ('cuda', 'mps'):
@@ -237,7 +250,9 @@ def run_normal_param_estimation_workflow(run_config: RunConfigData) -> None:
 
         # Create a partial function with the memory strategy and device
         worker_fn = partial(
-            _process_normal_params, memory_strategy=run_config.memory_strategy, device=run_config.device
+            _process_normal_params, memory_strategy=run_config.memory_strategy, device=run_config.device,
+            stride=run_config.stride_for_norm_param_estimation, optimize=run_config.optimize,
+            batch_size=run_config.batch_size_for_norm_param_estimation
         )
 
         # Start a pool of workers


### PR DESCRIPTION
Expose batch_size, stride and optimization params from transformer in opera-adt/distmetrics#40

Runconfig now supports: `stride_for_norm_param_estimation`, `batch_size_for_norm_param_estimation`, `optimize`