### PR TITLE
Algo config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 - All the tests with the updates above.
+- Correct loading of algo_config.yml in `prep` steps.
+  - Only `from_yml` loads the algo_config correctly, but when it is assigned in the `prep` workflows, it is not corrected.
 
 
 ## [1.0.1] - 2025-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Fixed
 - All the tests with the updates above.
 - Correct loading of algo_config.yml in `prep` steps.
-  - Only `from_yml` loads the algo_config correctly, but when it is assigned in the `prep` workflows, it is not corrected.
+  - Only `from_yml` loads the `algo_config` correctly, but when it is assigned in the `prep` workflows (i.e. the attribute `algo_config` is assigned, this yml is not correctly loaded.
 
 
 ## [1.0.1] - 2025-06-05

--- a/src/dist_s1/data_models/runconfig_model.py
+++ b/src/dist_s1/data_models/runconfig_model.py
@@ -539,13 +539,24 @@ class RunConfigData(AlgoConfigData):
                     current_value = getattr(self, field_name)
                     default_value = default_values.get(field_name)
 
+                    # If the current value is the default, we assume user did not set it and we load it
+                    # from the external yml file.
                     if current_value == default_value:
                         object.__setattr__(self, field_name, field_value)
                         warnings.warn(
-                            f"Algorithm parameter '{field_name}' loaded from external config: {self.algo_config_path}",
+                            f'Algorithm parameter "{field_name}" loaded from external config: {self.algo_config_path} '
+                            'to non-default value.',
                             UserWarning,
                             stacklevel=2,
                         )
+                    else:
+                        warnings.warn(
+                            f'Algorithm parameter "{field_name}" is already set to {current_value} in model '
+                            '(non-default value) and will not be overridden by algo_config.yml.',
+                            UserWarning,
+                            stacklevel=2,
+                        )
+
             self._algo_config_loaded = True
 
         return self

--- a/src/dist_s1/data_models/runconfig_model.py
+++ b/src/dist_s1/data_models/runconfig_model.py
@@ -88,7 +88,7 @@ class RunConfigData(AlgoConfigData):
     _product_data_model: ProductDirectoryData | None = None
     _min_acq_date: datetime | None = None
     _processing_datetime: datetime | None = None
-    _algo_config_loaded: bool = False  # Track if algorithm config has been loaded
+    _algo_config_loaded: bool = False
     # Validate assignments to all fields
     model_config = ConfigDict(validate_assignment=True)
 


### PR DESCRIPTION
Resolves #97 

Only `from_yml` loads the `algo_config` correctly, but when it is assigned in the `prep` workflows (i.e. the attribute `algo_config` is assigned, this yml is not correctly loaded.